### PR TITLE
Support vmxnet3 interfaces

### DIFF
--- a/bridgefix.sh
+++ b/bridgefix.sh
@@ -63,6 +63,7 @@ function fixup_bridge_fdb {
           bridge)  bridge=${kv[1]};;
           virtio)  macaddr=${kv[1]};;
           hwaddr)  macaddr=${kv[1]};;
+          vmxnet3)  macaddr=${kv[1]};;
         esac
       done
       # special processing needed if member of vlan


### PR DESCRIPTION
Some of the VMs I run specifically need `vmxnet3`, and don't support a VF or `virtio`. Figured I'd put this upstream rather than just doing the code locally :)